### PR TITLE
Add missing type info to snakemake expand

### DIFF
--- a/snakebids/core/datasets.py
+++ b/snakebids/core/datasets.py
@@ -13,7 +13,7 @@ import more_itertools as itx
 from bids import BIDSLayout
 from cached_property import cached_property
 from pvandyken.deprecated import deprecated
-from snakemake.io import expand as sn_expand  # type: ignore
+from snakemake.io import expand as sn_expand
 from typing_extensions import TypedDict
 
 import snakebids.utils.sb_itertools as sb_it

--- a/typings/snakemake/io.pyi
+++ b/typings/snakemake/io.pyi
@@ -5,7 +5,8 @@ from __future__ import annotations
 
 import os
 from contextlib import contextmanager
-from typing import Any, Generic, Iterable, List, TypeVar
+from pathlib import Path
+from typing import Any, Callable, Generic, Iterable, List, Sequence, TypeVar, overload
 
 __author__ = ...
 __copyright__ = ...
@@ -280,7 +281,12 @@ def local(value):  # -> AnnotatedString | list[Unknown]:
     """
     ...
 
-def expand(*args, **wildcards) -> list[str]:
+def expand(
+    filepatterns: Sequence[Path | str] | Path | str,
+    func: Callable[[Iterable[str]], Iterable[Iterable[str]]] | None = ...,
+    allow_missing: bool | Sequence[str] | str = ...,
+    **wildcards: Sequence[str] | str,
+) -> list[str]:
     """
     Expand wildcards in given filepatterns.
 


### PR DESCRIPTION
Can remove the `type: ignore` by adding a bit more information to the pyi file